### PR TITLE
The setting for <is_multi_select> in <ezselection> seems the wrong way round. Reverse the values.

### DIFF
--- a/lib/AttributeFunctions.php
+++ b/lib/AttributeFunctions.php
@@ -256,11 +256,11 @@ class AttributeFunctions
                 // set multi-select versus single selection
                 if( 0 == trim( $newAttributeXPath->query( "//newattribute/additional_for_specific_datatype/ezselection/is_multi_select" )->item( 0 )->nodeValue ) )
                 {
-                    $classAttribute->setAttribute( "data_int1", 1 );
+                    $classAttribute->setAttribute( "data_int1", 0 );
                 }
                 else
                 {
-                    $classAttribute->setAttribute( "data_int1", 0 );                
+                    $classAttribute->setAttribute( "data_int1", 1 );
                 }
                 break;
             


### PR DESCRIPTION
It seems the value for `<is_multi_select>` should be reversed.
The value stored in eZ Publish is what a programmer would expect:
- 1 means it is a multi-select
- 0 means it is not a multi-select.

But the previous code was reversing the values:
`<is_multi_select>1</is_multi_select>` would mean it is not a multi-select.
This is counter-intuitive. Can we change it?

Thanks!

Andy
